### PR TITLE
Rename endpoint classes and validators

### DIFF
--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -24,7 +24,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import SaveDefaultSwitchCredentials
+from nd_python.endpoints.manage import EpSaveDefaultSwitchCredentials
 
 
 class CredentialsDefaultSwitchSave:
@@ -42,7 +42,7 @@ class CredentialsDefaultSwitchSave:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = SaveDefaultSwitchCredentials()
+        self.endpoint = EpSaveDefaultSwitchCredentials()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -1,11 +1,11 @@
-from nd_python.validators.endpoints.manage import EpSaveDefaultSwitchCredentials
+from nd_python.validators.endpoints.manage import EpSaveDefaultSwitchCredentialsValidator
 from pydantic import ValidationError
 
 base = "/api/v1/manage"
 credentials = f"{base}/credentials"
 
 
-class DeleteDefaultSwitchCredentials:
+class EpDeleteDefaultSwitchCredentials:
     """Endpoint to delete default switch credentials"""
 
     def __init__(self):
@@ -14,7 +14,7 @@ class DeleteDefaultSwitchCredentials:
         self.description = "Delete Default Switch Credentials"
 
 
-class GetCredentialsDetails:
+class EpGetCredentialsDetails:
     """Endpoint to get credentials details"""
 
     def __init__(self):
@@ -23,7 +23,7 @@ class GetCredentialsDetails:
         self.description = "Get Credentials Details"
 
 
-class GetDefaultSwitchCredentials:
+class EpGetDefaultSwitchCredentials:
     """Endpoint to get default switch credentials"""
 
     def __init__(self):
@@ -32,7 +32,7 @@ class GetDefaultSwitchCredentials:
         self.description = "Get Default Switch Credentials"
 
 
-class SaveDefaultSwitchCredentials:
+class EpSaveDefaultSwitchCredentials:
     """
     # Summary
 
@@ -51,7 +51,7 @@ class SaveDefaultSwitchCredentials:
 
     def __init__(self):
         self._committed = False
-        self.validator = EpSaveDefaultSwitchCredentials
+        self.validator = EpSaveDefaultSwitchCredentialsValidator
         self._body = {}
         self.verb = "POST"
         self.path = f"{credentials}/defaultSwitchCredentials"

--- a/lib/nd_python/validators/endpoints/manage.py
+++ b/lib/nd_python/validators/endpoints/manage.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
 
-class EpSaveDefaultSwitchCredentials(BaseModel):
+class EpSaveDefaultSwitchCredentialsValidator(BaseModel):
     """Save Default Switch Credentials Endpoint Payload Model"""
 
     switch_username: str = Field(..., alias="switchUsername", description="Switch Username")


### PR DESCRIPTION
Standardize naming for endpoints and endpoint validators.

1. Preface all endpoint classes with “Ep”

2. Rename validator class to include “Validator” in the name.