### PR TITLE
sender_request.py: Improve type hinting

### DIFF
--- a/lib/nd_python/common/sender_requests.py
+++ b/lib/nd_python/common/sender_requests.py
@@ -516,7 +516,7 @@ class Sender:
         return self._ip6
 
     @ip6.setter
-    def ip6(self, value) -> None:
+    def ip6(self, value: str) -> None:
         self._ip6 = value
 
     @property


### PR DESCRIPTION
1. rename get_url to set_url since this method does not return anything.

2. Update type hints throughout to satisfy mypy