### PR TITLE
CredentialsDetailsGet: example script and library

### DIFF
--- a/examples/credentials_details_get.py
+++ b/examples/credentials_details_get.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+# credentials_details_get.py
+
+## Description
+
+Retrieve credentials details from the controller.
+
+Controller credentials are not to be confused with script credentials.
+
+## Usage
+
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/nd-python/lib
+```
+
+2. Optional, to enable logging.
+
+``` bash
+export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
+```
+
+3. Set credentials via script command line, environment variables, or Ansible Vault
+
+4. Run the script (below we're using command line for credentials)
+
+``` bash
+./examples/credentials_details_get.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password password \
+    --nd-username admin
+
+```
+
+"""
+# pylint: disable=duplicate-code
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import argparse
+import json
+import logging
+import sys
+
+from nd_python.common.nd_python_logger import NdPythonLogger
+from nd_python.common.nd_python_sender import NdPythonSender
+from nd_python.common.response_handler import ResponseHandler
+from nd_python.common.rest_send_v2 import RestSend
+from nd_python.credentials.credentials_details_get import CredentialsDetailsGet
+from nd_python.parsers.parser_ansible_vault import parser_ansible_vault
+from nd_python.parsers.parser_loglevel import parser_loglevel
+from nd_python.parsers.parser_nd_domain import parser_nd_domain
+from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from nd_python.parsers.parser_nd_password import parser_nd_password
+from nd_python.parsers.parser_nd_username import parser_nd_username
+
+
+def action() -> None:
+    """
+    Given a validated configuration, retrieve credentials details from the controller.
+    """
+    # Prepopulate error message in case of failure
+    errmsg = "Error retrieving credentials details. "
+    try:
+        instance = CredentialsDetailsGet()
+        instance.rest_send = rest_send
+        instance.commit()
+    except ValueError as error:
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    result_msg = "Credentials details:\n"
+    result_msg += f" {json.dumps(instance.data, indent=4, sort_keys=True)}"
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Retrieve credentials details from the controller.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdPythonLogger()
+log = logging.getLogger("nd_python.main")
+log.setLevel(args.loglevel)
+
+try:
+    nd_sender = NdPythonSender()
+    nd_sender.args = args
+    nd_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = nd_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+action()

--- a/lib/nd_python/credentials/credentials_details_get.py
+++ b/lib/nd_python/credentials/credentials_details_get.py
@@ -1,0 +1,86 @@
+"""
+# Name
+
+credentials_details_get.py
+
+# Description
+
+Retrieve credentials details from the controller.
+
+# Payload Example
+
+This endpoint does not require a payload.
+"""
+
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import inspect
+import logging
+
+from nd_python.common.properties import Properties
+from nd_python.endpoints.manage import EpCredentialsDetailsGet
+
+
+class CredentialsDetailsGet:
+    """
+    # Summary
+
+    Get credentials details from the controller.
+
+    ## Example get request
+
+    ### See
+
+    ./examples/credentials_details_get.py
+    """
+
+    def __init__(self) -> None:
+        self.class_name = self.__class__.__name__
+        self.endpoint = EpCredentialsDetailsGet()
+        self.log = logging.getLogger(f"nd_python.{self.class_name}")
+        self.properties = Properties()
+        self.rest_send = self.properties.rest_send
+        self._committed = False
+
+    def _final_verification(self) -> None:
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+    def commit(self) -> None:
+        """
+        Retrieve credentials details from the controller
+        """
+        method_name = inspect.stack()[0][3]
+        self._final_verification()
+
+        try:
+            self.rest_send.path = self.endpoint.path
+            self.rest_send.verb = self.endpoint.verb
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to get {self.rest_send.verb} request from the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._committed = True
+
+    @property
+    def data(self) -> dict:
+        """
+        Get the data from the response
+        """
+        method_name = inspect.stack()[0][3]
+        if not self._committed:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.commit() must be called before accessing data"
+            raise ValueError(msg)
+        return self.rest_send.response_current.get("DATA", {})

--- a/lib/nd_python/credentials/credentials_details_get.py
+++ b/lib/nd_python/credentials/credentials_details_get.py
@@ -68,7 +68,7 @@ class CredentialsDetailsGet:
             self.rest_send.commit()
         except (TypeError, ValueError) as error:
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"Unable to get {self.rest_send.verb} request from the controller. "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
             msg += f"Error details: {error}"
             raise ValueError(msg) from error
         self._committed = True

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -14,7 +14,7 @@ class EpDeleteDefaultSwitchCredentials:
         self.description = "Delete Default Switch Credentials"
 
 
-class EpGetCredentialsDetails:
+class EpCredentialsDetailsGet:
     """Endpoint to get credentials details"""
 
     def __init__(self):


### PR DESCRIPTION
This commit introduces an example library and script to retrieve credentials details from the controller.

NOTE: We have changed the endpoint class naming convention with this commit.  We need to go back and change the existing endpoints to follow the new convention.  We'll do this in the next PR.