### PR TITLE
Rename Endpoint classes (again)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,11 +53,11 @@ rest_send.response_handler = ResponseHandler()
 
 ### Endpoint Definition Pattern
 ```python
-class EpDefaultSwitchCredentialsSave:
+class EpCredentialsDefaultSwitchSave:
     def __init__(self):
         self.verb = "POST"
         self.path = f"{base_url}/defaultSwitchCredentials"
-        self.validator = EpDefaultSwitchCredentialsSaveValidator
+        self.validator = EpCredentialsDefaultSwitchSaveValidator
         
     def commit(self):
         # Pydantic validation before use

--- a/lib/nd_python/credentials/default_switch_delete.py
+++ b/lib/nd_python/credentials/default_switch_delete.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpDefaultSwitchCredentialsDelete
+from nd_python.endpoints.manage import EpCredentialsDefaultSwitchDelete
 
 
 class CredentialsDefaultSwitchDelete:
@@ -34,7 +34,7 @@ class CredentialsDefaultSwitchDelete:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpDefaultSwitchCredentialsDelete()
+        self.endpoint = EpCredentialsDefaultSwitchDelete()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/credentials/default_switch_get.py
+++ b/lib/nd_python/credentials/default_switch_get.py
@@ -19,7 +19,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpDefaultSwitchCredentialsGet
+from nd_python.endpoints.manage import EpCredentialsDefaultSwitchGet
 
 
 class CredentialsDefaultSwitchGet:
@@ -37,7 +37,7 @@ class CredentialsDefaultSwitchGet:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpDefaultSwitchCredentialsGet()
+        self.endpoint = EpCredentialsDefaultSwitchGet()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -24,7 +24,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpDefaultSwitchCredentialsSave
+from nd_python.endpoints.manage import EpCredentialsDefaultSwitchSave
 
 
 class CredentialsDefaultSwitchSave:
@@ -42,7 +42,7 @@ class CredentialsDefaultSwitchSave:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpDefaultSwitchCredentialsSave()
+        self.endpoint = EpCredentialsDefaultSwitchSave()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -1,11 +1,11 @@
-from nd_python.validators.endpoints.manage import EpDefaultSwitchCredentialsSaveValidator
+from nd_python.validators.endpoints.manage import EpCredentialsDefaultSwitchSaveValidator
 from pydantic import ValidationError
 
 base = "/api/v1/manage"
 credentials = f"{base}/credentials"
 
 
-class EpDefaultSwitchCredentialsDelete:
+class EpCredentialsDefaultSwitchDelete:
     """Endpoint to delete default switch credentials"""
 
     def __init__(self):
@@ -23,7 +23,7 @@ class EpCredentialsDetailsGet:
         self.description = "Get Credentials Details"
 
 
-class EpDefaultSwitchCredentialsGet:
+class EpCredentialsDefaultSwitchGet:
     """Endpoint to get default switch credentials"""
 
     def __init__(self):
@@ -32,7 +32,7 @@ class EpDefaultSwitchCredentialsGet:
         self.description = "Get Default Switch Credentials"
 
 
-class EpDefaultSwitchCredentialsSave:
+class EpCredentialsDefaultSwitchSave:
     """
     # Summary
 
@@ -41,7 +41,7 @@ class EpDefaultSwitchCredentialsSave:
     ## Usage
 
     ```python
-    ep = EpDefaultSwitchCredentialsSave()
+    ep = EpCredentialsDefaultSwitchSave()
     ep.switch_username = "admin"
     ep.switch_password = "password"
     ep.commit()
@@ -51,7 +51,7 @@ class EpDefaultSwitchCredentialsSave:
 
     def __init__(self):
         self._committed = False
-        self.validator = EpDefaultSwitchCredentialsSaveValidator
+        self.validator = EpCredentialsDefaultSwitchSaveValidator
         self._body = {}
         self.verb = "POST"
         self.path = f"{credentials}/defaultSwitchCredentials"
@@ -73,28 +73,28 @@ class EpDefaultSwitchCredentialsSave:
         return self._body
 
     @property
-    def switch_password(self):
+    def switch_password(self) -> str:
         """Set (setter) or return (getter) the switch password"""
         return self._body.get("switchPassword")
 
     @switch_password.setter
-    def switch_password(self, value):
+    def switch_password(self, value: str) -> None:
         self._body["switchPassword"] = value
 
     @property
-    def switch_username(self):
+    def switch_username(self) -> str:
         """Set (setter) or return (getter) the switch username"""
         return self._body.get("switchUsername")
 
     @switch_username.setter
-    def switch_username(self, value):
+    def switch_username(self, value: str) -> None:
         self._body["switchUsername"] = value
 
 
-class EpRobotSwitchCredentialsGet:
+class EpCredentialsRobotSwitchGet:
     """Endpoint to get robot switch credentials"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.verb = "GET"
         self.path = f"{credentials}/robotSwitchCredentials"
         self.description = "Get Robot Switch Credentials"

--- a/lib/nd_python/validators/endpoints/manage.py
+++ b/lib/nd_python/validators/endpoints/manage.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
 
-class EpDefaultSwitchCredentialsSaveValidator(BaseModel):
+class EpCredentialsDefaultSwitchSaveValidator(BaseModel):
     """Save Default Switch Credentials Endpoint Payload Model"""
 
     switch_username: str = Field(..., alias="switchUsername", description="Switch Username")


### PR DESCRIPTION
Previous endpoint class names were of the form

Ep + Noun + Verb

Where Noun was DefaultSwitchCredentials.

In a future PR, we will introduce the following API sections:

- RobotSwitchCredentials
- UserSwitchCredentials
- SwitchCredentials

For better grouping, Noun should start with Credentials.  Hence, the new naming will be:

EpCredentials + DefaultSwitch + Verb
EpCredentials + Switch + Verb
EpCredentials + UserSwitch + Verb
etc…

This commit changes exising endpoint class names to follow the above convention.

This commit also fixes a few type-hints in lib/nd_python/endpoints/manage.py