### PR TITLE
Fix endpoint names missed in the last commit, more

### DIFF
--- a/examples/credentials_robot_switch_delete.py
+++ b/examples/credentials_robot_switch_delete.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+# credentials_robot_switch_delete.py
+
+## Description
+
+Delete robot switch credentials from the controller.
+
+This script does not take any arguments beyond those needed to connect
+to the controller, so does not require a configuration file.
+
+## Usage
+
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/nd-python/lib
+```
+
+2. Optional, to enable logging.
+
+``` bash
+export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
+```
+
+3. Set credentials via script command line, environment variables, or Ansible Vault
+
+4. Run the script (below we're using command line for credentials)
+
+``` bash
+./examples/credentials_robot_switch_delete.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password password \
+    --nd-username admin
+```
+
+"""
+# pylint: disable=duplicate-code
+import argparse
+import logging
+import sys
+
+from nd_python.common.nd_python_logger import NdPythonLogger
+from nd_python.common.nd_python_sender import NdPythonSender
+from nd_python.common.response_handler import ResponseHandler
+from nd_python.common.rest_send_v2 import RestSend
+from nd_python.credentials.robot_switch_delete import CredentialsRobotSwitchDelete
+from nd_python.parsers.parser_ansible_vault import parser_ansible_vault
+from nd_python.parsers.parser_loglevel import parser_loglevel
+from nd_python.parsers.parser_nd_domain import parser_nd_domain
+from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from nd_python.parsers.parser_nd_password import parser_nd_password
+from nd_python.parsers.parser_nd_username import parser_nd_username
+
+
+def action() -> None:
+    """
+    Delete the robot switch credentials.
+    """
+    # Prepopulate error message in case of failure
+    errmsg = "Error deleting robot switch credentials. "
+    try:
+        instance = CredentialsRobotSwitchDelete()
+        instance.rest_send = rest_send
+        instance.commit()
+    except ValueError as error:
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    result_msg = "Robot switch credentials deleted."
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Delete robot switch credentials from the controller.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdPythonLogger()
+log = logging.getLogger("nd_python.main")
+log.setLevel(args.loglevel)
+
+try:
+    nd_sender = NdPythonSender()
+    nd_sender.args = args
+    nd_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = nd_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+action()

--- a/examples/credentials_robot_switch_save.py
+++ b/examples/credentials_robot_switch_save.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+# credentials_robot_switch_save.py
+
+## Description
+
+Save robot switch credentials to the controller.
+
+## Usage
+
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/nd-python/lib
+```
+
+2. Optional, to enable logging.
+
+``` bash
+export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
+```
+
+3. Edit ./examples/config/credentials_robot_switch_save.yaml with desired values
+
+4. Set credentials via script command line, environment variables, or Ansible Vault
+
+5. Run the script (below we're using command line for credentials)
+
+``` bash
+./examples/credentials_robot_switch_save.py \
+    --config ./examples/config/credentials_robot_switch_save.yaml \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password password \
+    --nd-username admin
+
+```
+
+"""
+# pylint: disable=duplicate-code
+import argparse
+import logging
+import sys
+
+from nd_python.common.nd_python_logger import NdPythonLogger
+from nd_python.common.nd_python_sender import NdPythonSender
+from nd_python.common.read_config import ReadConfig
+from nd_python.common.response_handler import ResponseHandler
+from nd_python.common.rest_send_v2 import RestSend
+from nd_python.credentials.robot_switch_save import CredentialsRobotSwitchSave
+from nd_python.parsers.parser_ansible_vault import parser_ansible_vault
+from nd_python.parsers.parser_config import parser_config
+from nd_python.parsers.parser_loglevel import parser_loglevel
+from nd_python.parsers.parser_nd_domain import parser_nd_domain
+from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from nd_python.parsers.parser_nd_password import parser_nd_password
+from nd_python.parsers.parser_nd_username import parser_nd_username
+from nd_python.validators.credentials_robot_switch_save import CredentialsRobotSwitchSaveConfigValidator
+from pydantic import ValidationError
+
+
+def action(cfg: CredentialsRobotSwitchSaveConfigValidator) -> None:
+    """
+    Given a validated configuration, save the robot switch credentials.
+    """
+    # Prepopulate error message in case of failure
+    errmsg = f"Error saving robot switch credentials for {cfg.switch_username}, "
+    try:
+        instance = CredentialsRobotSwitchSave()
+        instance.rest_send = rest_send
+        instance.switch_username = cfg.switch_username
+        instance.switch_password = cfg.switch_password
+        instance.commit()
+    except ValueError as error:
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    result_msg = f"robot switch credentials saved for user {cfg.switch_username}"
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Save robot switch credentials to the controller.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdPythonLogger()
+log = logging.getLogger("nd_python.main")
+log.setLevel(args.loglevel)
+
+try:
+    user_config = ReadConfig()
+    user_config.filename = args.config
+    user_config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    validator = CredentialsRobotSwitchSaveConfigValidator(**user_config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    nd_sender = NdPythonSender()
+    nd_sender.args = args
+    nd_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = nd_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+action(validator)

--- a/lib/nd_python/credentials/credentials_details_get.py
+++ b/lib/nd_python/credentials/credentials_details_get.py
@@ -73,7 +73,7 @@ class CredentialsDetailsGet:
             raise ValueError(msg) from error
         self._committed = True
 
-    def error_if_not_committed(self, method_name) -> None:
+    def error_if_not_committed(self, method_name: str) -> None:
         """
         Raise an error if .commit() has not been called
         """

--- a/lib/nd_python/credentials/default_switch_delete.py
+++ b/lib/nd_python/credentials/default_switch_delete.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpDefaultSwitchCredentialsDelete
+from nd_python.endpoints.manage import EpCredentialsDefaultSwitchDelete
 
 
 class CredentialsDefaultSwitchDelete:
@@ -34,7 +34,7 @@ class CredentialsDefaultSwitchDelete:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpDefaultSwitchCredentialsDelete()
+        self.endpoint = EpCredentialsDefaultSwitchDelete()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -112,7 +112,7 @@ class CredentialsDefaultSwitchSave:
         return self._switch_password
 
     @switch_password.setter
-    def switch_password(self, value):
+    def switch_password(self, value: str) -> None:
         self._switch_password = value
 
     @property
@@ -123,5 +123,5 @@ class CredentialsDefaultSwitchSave:
         return self._switch_username
 
     @switch_username.setter
-    def switch_username(self, value):
+    def switch_username(self, value: str) -> None:
         self._switch_username = value

--- a/lib/nd_python/credentials/robot_switch_delete.py
+++ b/lib/nd_python/credentials/robot_switch_delete.py
@@ -1,15 +1,12 @@
 """
 # Name
 
-default_switch_get.py
+robot_switch_delete.py
 
 # Description
 
-Retrieve default switch credentials from the controller.
+Delete robot switch credentials from the controller.
 
-# Payload Example
-
-This endpoint does not require a payload.
 """
 
 # We are using isort for import sorting.
@@ -19,29 +16,28 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpCredentialsDefaultSwitchGet
+from nd_python.endpoints.manage import EpCredentialsRobotSwitchDelete
 
 
-class CredentialsDefaultSwitchGet:
+class CredentialsRobotSwitchDelete:
     """
     # Summary
 
-    Get default switch credentials from the controller.
+    Delete robot switch credentials from the controller.
 
-    ## Example default switch get request
+    ## Example robot switch delete request
 
     ### See
 
-    ./examples/credentials_default_switch_get.py
+    ./examples/credentials_robot_switch_delete.py
     """
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpCredentialsDefaultSwitchGet()
+        self.endpoint = EpCredentialsRobotSwitchDelete()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
-        self._committed = False
 
     def _final_verification(self) -> None:
         """
@@ -57,7 +53,7 @@ class CredentialsDefaultSwitchGet:
 
     def commit(self) -> None:
         """
-        Retrieve default switch credentials from the controller
+        Delete robot switch credentials from the controller.
         """
         method_name = inspect.stack()[0][3]
         self._final_verification()
@@ -68,19 +64,6 @@ class CredentialsDefaultSwitchGet:
             self.rest_send.commit()
         except (TypeError, ValueError) as error:
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"Unable to get {self.rest_send.verb} request from the controller. "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
             msg += f"Error details: {error}"
             raise ValueError(msg) from error
-        self._committed = True
-
-    @property
-    def data(self) -> dict:
-        """
-        Get the data from the response
-        """
-        method_name = inspect.stack()[0][3]
-        if not self._committed:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"{self.class_name}.commit() must be called before accessing data"
-            raise ValueError(msg)
-        return self.rest_send.response_current.get("DATA", {})

--- a/lib/nd_python/credentials/robot_switch_get.py
+++ b/lib/nd_python/credentials/robot_switch_get.py
@@ -19,7 +19,7 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpRobotSwitchCredentialsGet
+from nd_python.endpoints.manage import EpCredentialsRobotSwitchGet
 
 
 class CredentialsRobotSwitchGet:
@@ -37,7 +37,7 @@ class CredentialsRobotSwitchGet:
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpRobotSwitchCredentialsGet()
+        self.endpoint = EpCredentialsRobotSwitchGet()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send

--- a/lib/nd_python/credentials/robot_switch_save.py
+++ b/lib/nd_python/credentials/robot_switch_save.py
@@ -1,11 +1,11 @@
 """
 # Name
 
-default_switch_save.py
+robot_switch_save.py
 
 # Description
 
-Save default switch credentials to the controller.
+Save robot switch credentials to the controller.
 
 # Payload Example
 
@@ -24,25 +24,25 @@ import inspect
 import logging
 
 from nd_python.common.properties import Properties
-from nd_python.endpoints.manage import EpCredentialsDefaultSwitchSave
+from nd_python.endpoints.manage import EpCredentialsRobotSwitchSave
 
 
-class CredentialsDefaultSwitchSave:
+class CredentialsRobotSwitchSave:
     """
     # Summary
 
-    Save default switch credentials to the controller.
+    Save robot switch credentials to the controller.
 
-    ## Example default switch save request
+    ## Example robot switch save request
 
     ### See
 
-    ./examples/credentials_default_switch_save.py
+    ./examples/credentials_robot_switch_save.py
     """
 
     def __init__(self) -> None:
         self.class_name = self.__class__.__name__
-        self.endpoint = EpCredentialsDefaultSwitchSave()
+        self.endpoint = EpCredentialsRobotSwitchSave()
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
@@ -68,6 +68,7 @@ class CredentialsDefaultSwitchSave:
             msg += f"Call {self.class_name}.switch_username "
             msg += f"before calling {self.class_name}.commit"
             raise ValueError(msg)
+
         if self._switch_password == "":
             msg = f"{self.class_name}.{method_name}: "
             msg += f"Call {self.class_name}.switch_password "
@@ -76,7 +77,7 @@ class CredentialsDefaultSwitchSave:
 
     def commit(self) -> None:
         """
-        Create a network
+        Save robot switch credentials to the controller.
         """
         method_name = inspect.stack()[0][3]
         self._final_verification()
@@ -93,6 +94,7 @@ class CredentialsDefaultSwitchSave:
 
         self._payload["switchUsername"] = self.endpoint.switch_username
         self._payload["switchPassword"] = self.endpoint.switch_password
+        self._payload["isRobot"] = True
         try:
             self.rest_send.path = self.endpoint.path
             self.rest_send.verb = self.endpoint.verb

--- a/lib/nd_python/credentials/robot_switch_save.py
+++ b/lib/nd_python/credentials/robot_switch_save.py
@@ -114,7 +114,7 @@ class CredentialsRobotSwitchSave:
         return self._switch_password
 
     @switch_password.setter
-    def switch_password(self, value):
+    def switch_password(self, value: str) -> None:
         self._switch_password = value
 
     @property
@@ -125,5 +125,5 @@ class CredentialsRobotSwitchSave:
         return self._switch_username
 
     @switch_username.setter
-    def switch_username(self, value):
+    def switch_username(self, value: str) -> None:
         self._switch_username = value

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -1,14 +1,14 @@
-from nd_python.validators.endpoints.manage import EpDefaultSwitchCredentialsSaveValidator
+from nd_python.validators.endpoints.manage import EpCredentialsDefaultSwitchSaveValidator, EpCredentialsRobotSwitchSaveValidator
 from pydantic import ValidationError
 
 base = "/api/v1/manage"
 credentials = f"{base}/credentials"
 
 
-class EpDefaultSwitchCredentialsDelete:
+class EpCredentialsDefaultSwitchDelete:
     """Endpoint to delete default switch credentials"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.verb = "DELETE"
         self.path = f"{credentials}/defaultSwitchCredentials"
         self.description = "Delete Default Switch Credentials"
@@ -17,22 +17,22 @@ class EpDefaultSwitchCredentialsDelete:
 class EpCredentialsDetailsGet:
     """Endpoint to get credentials details"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.verb = "GET"
         self.path = f"{credentials}/details"
         self.description = "Get Credentials Details"
 
 
-class EpDefaultSwitchCredentialsGet:
+class EpCredentialsDefaultSwitchGet:
     """Endpoint to get default switch credentials"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.verb = "GET"
         self.path = f"{credentials}/defaultSwitchCredentials"
         self.description = "Get Default Switch Credentials"
 
 
-class EpDefaultSwitchCredentialsSave:
+class EpCredentialsDefaultSwitchSave:
     """
     # Summary
 
@@ -41,7 +41,7 @@ class EpDefaultSwitchCredentialsSave:
     ## Usage
 
     ```python
-    ep = EpDefaultSwitchCredentialsSave()
+    ep = EpCredentialsDefaultSwitchSave()
     ep.switch_username = "admin"
     ep.switch_password = "password"
     ep.commit()
@@ -49,15 +49,15 @@ class EpDefaultSwitchCredentialsSave:
     ```
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._committed = False
-        self.validator = EpDefaultSwitchCredentialsSaveValidator
-        self._body = {}
+        self.validator = EpCredentialsDefaultSwitchSaveValidator
+        self._body: dict = {}
         self.verb = "POST"
         self.path = f"{credentials}/defaultSwitchCredentials"
         self.description = "Save Default Switch Credentials"
 
-    def commit(self):
+    def commit(self) -> None:
         """commit the endpoint"""
         try:
             self.validator(**self._body)
@@ -73,28 +73,97 @@ class EpDefaultSwitchCredentialsSave:
         return self._body
 
     @property
-    def switch_password(self):
+    def switch_password(self) -> str:
         """Set (setter) or return (getter) the switch password"""
-        return self._body.get("switchPassword")
+        return self._body.get("switchPassword", "")
 
     @switch_password.setter
-    def switch_password(self, value):
+    def switch_password(self, value: str) -> None:
         self._body["switchPassword"] = value
 
     @property
-    def switch_username(self):
+    def switch_username(self) -> str:
         """Set (setter) or return (getter) the switch username"""
-        return self._body.get("switchUsername")
+        return self._body.get("switchUsername", "")
 
     @switch_username.setter
-    def switch_username(self, value):
+    def switch_username(self, value: str) -> None:
         self._body["switchUsername"] = value
 
 
-class EpRobotSwitchCredentialsGet:
+class EpCredentialsRobotSwitchDelete:
+    """Endpoint to delete robot switch credentials"""
+
+    def __init__(self) -> None:
+        self.verb = "DELETE"
+        self.path = f"{credentials}/robotSwitchCredentials"
+        self.description = "Delete Robot Switch Credentials"
+
+
+class EpCredentialsRobotSwitchGet:
     """Endpoint to get robot switch credentials"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.verb = "GET"
         self.path = f"{credentials}/robotSwitchCredentials"
         self.description = "Get Robot Switch Credentials"
+
+
+class EpCredentialsRobotSwitchSave:
+    """
+    # Summary
+
+    Endpoint to save robot switch credentials
+
+    ## Usage
+
+    ```python
+    ep = EpCredentialsRobotSwitchSave()
+    ep.switch_username = "admin"
+    ep.switch_password = "password"
+    ep.commit()
+    response = client.request(ep.verb, ep.path, json=ep.body)
+    ```
+    """
+
+    def __init__(self) -> None:
+        self._committed = False
+        self.validator = EpCredentialsRobotSwitchSaveValidator
+        self._body: dict = {}
+        self.verb = "POST"
+        self.path = f"{credentials}/robotSwitchCredentials"
+        self.description = "Save Robot Switch Credentials"
+
+    def commit(self) -> None:
+        """commit the endpoint"""
+        try:
+            self.validator(**self._body)
+        except ValidationError as error:
+            raise ValueError(f"Invalid request body: {error}") from error
+        self._committed = True
+
+    @property
+    def body(self) -> dict:
+        """return a dictionary representing the endpoint payload"""
+        if not self._committed:
+            raise ValueError("Call instance.commit() before accessing instance.body.")
+        self._body["isRobot"] = True
+        return self._body
+
+    @property
+    def switch_password(self) -> str:
+        """Set (setter) or return (getter) the switch password"""
+        return self._body.get("switchPassword", "")
+
+    @switch_password.setter
+    def switch_password(self, value: str) -> None:
+        self._body["switchPassword"] = value
+
+    @property
+    def switch_username(self) -> str:
+        """Set (setter) or return (getter) the switch username"""
+        return self._body.get("switchUsername", "")
+
+    @switch_username.setter
+    def switch_username(self, value: str) -> None:
+        self._body["switchUsername"] = value

--- a/lib/nd_python/validators/credentials_robot_switch_save.py
+++ b/lib/nd_python/validators/credentials_robot_switch_save.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+
+
+class CredentialsRobotSwitchSaveConfigValidator(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for saving robot switch credentials.
+    """
+
+    switch_username: str = Field(..., min_length=1, description="Switch Username")
+    switch_password: str = Field(..., min_length=1, description="Switch Password")

--- a/lib/nd_python/validators/endpoints/manage.py
+++ b/lib/nd_python/validators/endpoints/manage.py
@@ -1,8 +1,24 @@
 from pydantic import BaseModel, Field
 
 
-class EpDefaultSwitchCredentialsSaveValidator(BaseModel):
+class EpCredentialsDefaultSwitchSaveValidator(BaseModel):
     """Save Default Switch Credentials Endpoint Payload Model"""
+
+    switch_username: str = Field(..., alias="switchUsername", description="Switch Username")
+    switch_password: str = Field(..., alias="switchPassword", description="Switch Password")
+
+    class Config:
+        """Pydantic configuration."""
+
+        validate_by_name = True
+        populate_by_alias = True
+        str_strip_whitespace = True
+        str_min_length = 1
+        extra = "forbid"
+
+
+class EpCredentialsRobotSwitchSaveValidator(BaseModel):
+    """Save Robot Switch Credentials Endpoint Payload Model"""
 
     switch_username: str = Field(..., alias="switchUsername", description="Switch Username")
     switch_password: str = Field(..., alias="switchPassword", description="Switch Password")


### PR DESCRIPTION
1. Fix endpoint names that we missed in the last commit to align them with the new naming convention.

2. Introduce CredentialsRobotSwitch operations examples for save and delete