### PR TITLE
Credentials user switch save

### DIFF
--- a/examples/config/credentials_user_switch_save.yaml
+++ b/examples/config/credentials_user_switch_save.yaml
@@ -1,0 +1,14 @@
+---
+config:
+  - fabric_name: SITE1
+    switch_name: LE1
+    switch_username: admin
+    switch_password: mySwitchPassword
+  - fabric_name: SITE1
+    switch_name: SP1
+    switch_username: admin
+    switch_password: mySwitchPassword
+  - fabric_name: SITE2
+    switch_name: LE2
+    switch_username: admin
+    switch_password: mySwitchPassword

--- a/examples/credentials_user_switch_save.py
+++ b/examples/credentials_user_switch_save.py
@@ -87,7 +87,7 @@ def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
         print(errmsg)
         return
 
-    print(f"switch_name {cfg.switch_name} switch_username {cfg.switch_username} switch credentials saved")
+    print(f"fabric_name {cfg.fabric_name} switch_name {cfg.switch_name} switch_username {cfg.switch_username} credentials saved")
 
 
 def setup_parser() -> argparse.Namespace:

--- a/examples/credentials_user_switch_save.py
+++ b/examples/credentials_user_switch_save.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+# credentials_user_switch_save.py
+
+## Description
+
+Save user switch credentials to the controller.
+
+## Usage
+
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/nd-python/lib
+```
+
+2. Optional, to enable logging.
+
+``` bash
+export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
+```
+
+3. Set credentials via script command line, environment variables, or Ansible Vault
+
+4. Run the script (below we're using command line for credentials)
+
+``` bash
+./examples/credentials_user_switch_save.py \
+    --config ./examples/config/credentials_user_switch_save.yaml \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password password \
+    --nd-username admin
+```
+
+## Notes
+
+The configuration file contains the following parameters:
+
+- config: Required; list of dictionaries with the following keys:
+  - switch_name: Required; name of the switch.
+  - switch_username: Required; username for the switch.
+  - switch_password: Required; password for the switch.
+"""
+# pylint: disable=duplicate-code
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import argparse
+import logging
+import sys
+
+from nd_python.common.nd_python_logger import NdPythonLogger
+from nd_python.common.nd_python_sender import NdPythonSender
+from nd_python.common.read_config import ReadConfig
+from nd_python.common.response_handler import ResponseHandler
+from nd_python.common.rest_send_v2 import RestSend
+from nd_python.credentials.user_switch_save import CredentialsUserSwitchSave
+from nd_python.parsers.parser_ansible_vault import parser_ansible_vault
+from nd_python.parsers.parser_config import parser_config
+from nd_python.parsers.parser_loglevel import parser_loglevel
+from nd_python.parsers.parser_nd_domain import parser_nd_domain
+from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from nd_python.parsers.parser_nd_password import parser_nd_password
+from nd_python.parsers.parser_nd_username import parser_nd_username
+from nd_python.validators.credentials.user_switch_save import CredentialsUserSwitchSaveConfigItem, CredentialsUserSwitchSaveConfigValidator
+from pydantic import ValidationError
+
+
+def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
+    """
+    Save user switch credentials.
+    """
+    # Prepopulate error message in case of failure
+    errmsg = "Error saving user switch credentials. "
+    try:
+        instance = CredentialsUserSwitchSave()
+        instance.rest_send = rest_send
+        instance.fabric_name = cfg.fabric_name
+        instance.switch_name = cfg.switch_name
+        instance.switch_username = cfg.switch_username
+        instance.switch_password = cfg.switch_password
+        instance.commit()
+    except ValueError as error:
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    print(f"switch_name {cfg.switch_name} switch_username {cfg.switch_username} switch credentials saved")
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Save user switch credentials to the controller.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdPythonLogger()
+log = logging.getLogger("nd_python.main")
+log.setLevel(args.loglevel)
+
+try:
+    user_config = ReadConfig()
+    user_config.filename = args.config
+    user_config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    validator = CredentialsUserSwitchSaveConfigValidator(**user_config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    nd_sender = NdPythonSender()
+    nd_sender.args = args
+    nd_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = nd_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+for item in validator.config:
+    action(item)

--- a/lib/nd_python/credentials/user_switch_save.py
+++ b/lib/nd_python/credentials/user_switch_save.py
@@ -1,7 +1,7 @@
 """
 # Name
 
-robot_switch_get.py
+user_switch_save.py
 
 # Description
 

--- a/lib/nd_python/credentials/user_switch_save.py
+++ b/lib/nd_python/credentials/user_switch_save.py
@@ -1,0 +1,167 @@
+"""
+# Name
+
+robot_switch_get.py
+
+# Description
+
+Save user switch credentials to the controller.
+
+# Payload Example
+
+```json
+{
+  "switchIds": [
+    {
+      "switchId": "SAL1948TRTT"
+    },
+    {
+      "switchId": "SAL1947TRAB"
+    }
+  ],
+  "switchPassword": "test",
+  "switchUsername": "admin"
+}
+```
+"""
+
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import inspect
+import logging
+from typing import Any
+
+from nd_python.common.properties import Properties
+from nd_python.endpoints.manage import EpCredentialsUserSwitchSave
+from nd_python.switches.inventory_get import SwitchesInventoryGet
+
+
+class CredentialsUserSwitchSave:
+    """
+    # Summary
+
+    Save user switch credentials to the controller.
+
+    ## Example user switch save request
+
+    ### See
+
+    ./examples/credentials_user_switch_save.py
+    """
+
+    def __init__(self) -> None:
+        self.class_name = self.__class__.__name__
+        self.endpoint = EpCredentialsUserSwitchSave()
+        self.inventory = SwitchesInventoryGet()
+        self.log = logging.getLogger(f"nd_python.{self.class_name}")
+        self.properties = Properties()
+        self.rest_send = self.properties.rest_send
+
+        self._committed = False
+        self._fabric_name = ""
+        self._payload: dict[str, Any] = {}
+        self._switch_name = ""
+        self._switch_username = ""
+        self._switch_password = ""
+
+    def _verify_property(self, method_name: str, property_name: str) -> None:
+        if not getattr(self, property_name, None):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.{property_name} must be set before callling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+    def _final_verification(self) -> None:
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        self._verify_property(method_name, "fabric_name")
+        self._verify_property(method_name, "rest_send")
+        self._verify_property(method_name, "switch_name")
+        self._verify_property(method_name, "switch_password")
+        self._verify_property(method_name, "switch_username")
+
+    def build_payload(self) -> None:
+        """
+        Build the payload for the request
+        """
+        self._payload = {}
+        self.inventory.fabric_name = self.fabric_name
+        self.inventory.rest_send = self.rest_send
+        self.inventory.commit()
+        serial_number = self.inventory.switch_name_to_serial_number(self.switch_name)
+        if not serial_number:
+            msg = f"switch_name {self.switch_name} not found in fabric {self.fabric_name}"
+            raise ValueError(msg)
+
+        self._payload = {
+            "switchIds": [{"switchId": serial_number}],
+            "switchUsername": self.switch_username,
+            "switchPassword": self.switch_password,
+        }
+
+    def commit(self) -> None:
+        """
+        Save user switch credentials to the controller
+        """
+        method_name = inspect.stack()[0][3]
+        self._final_verification()
+        self.build_payload()
+
+        try:
+            self.rest_send.path = self.endpoint.path
+            self.rest_send.verb = self.endpoint.verb
+            self.rest_send.payload = self._payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Error sending {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._committed = True
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        Set (setter) or return (getter) fabric_name
+        """
+        return self._fabric_name
+
+    @fabric_name.setter
+    def fabric_name(self, value: str) -> None:
+        self._fabric_name = value
+
+    @property
+    def switch_name(self) -> str:
+        """
+        Set (setter) or return (getter) switch_name
+        """
+        return self._switch_name
+
+    @switch_name.setter
+    def switch_name(self, value: str) -> None:
+        self._switch_name = value
+
+    @property
+    def switch_password(self) -> str:
+        """
+        Set (setter) or return (getter) switch_password
+        """
+        return self._switch_password
+
+    @switch_password.setter
+    def switch_password(self, value: str) -> None:
+        self._switch_password = value
+
+    @property
+    def switch_username(self) -> str:
+        """
+        Set (setter) or return (getter) switch_username
+        """
+        return self._switch_username
+
+    @switch_username.setter
+    def switch_username(self, value: str) -> None:
+        self._switch_username = value

--- a/lib/nd_python/credentials/user_switch_save.py
+++ b/lib/nd_python/credentials/user_switch_save.py
@@ -68,7 +68,7 @@ class CredentialsUserSwitchSave:
     def _verify_property(self, method_name: str, property_name: str) -> None:
         if not getattr(self, property_name, None):
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"{self.class_name}.{property_name} must be set before callling "
+            msg += f"{self.class_name}.{property_name} must be set before calling "
             msg += f"{self.class_name}.commit"
             raise ValueError(msg)
 

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -1,8 +1,6 @@
+from nd_python.endpoints.base.endpoint import credentials
 from nd_python.validators.endpoints.manage import EpCredentialsDefaultSwitchSaveValidator, EpCredentialsRobotSwitchSaveValidator
 from pydantic import ValidationError
-
-base = "/api/v1/manage"
-credentials = f"{base}/credentials"
 
 
 class EpCredentialsDefaultSwitchDelete:
@@ -176,3 +174,11 @@ class EpCredentialsUserSwitchGet:
         self.verb = "GET"
         self.path = f"{credentials}/switches"
         self.description = "Get User Switch Credentials"
+
+class EpCredentialsUserSwitchSave:
+    """Endpoint to save user switch credentials"""
+
+    def __init__(self) -> None:
+        self.verb = "POST"
+        self.path = f"{credentials}/switches"
+        self.description = "Save User Switch Credentials"

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -175,6 +175,7 @@ class EpCredentialsUserSwitchGet:
         self.path = f"{credentials}/switches"
         self.description = "Get User Switch Credentials"
 
+
 class EpCredentialsUserSwitchSave:
     """Endpoint to save user switch credentials"""
 

--- a/lib/nd_python/validators/credentials/user_switch_save.py
+++ b/lib/nd_python/validators/credentials/user_switch_save.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+
+class CredentialsUserSwitchSaveConfigItem(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for saving user switch credentials.
+    """
+
+    fabric_name: str = Field(..., min_length=1, max_length=64, description="Fabric Name")
+    switch_name: str = Field(..., min_length=1, description="Switch Name")
+    switch_username: str = Field(..., min_length=1, description="Switch Username")
+    switch_password: str = Field(..., min_length=1, description="Switch Password")
+
+
+class CredentialsUserSwitchSaveConfigValidator(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for saving user switch credentials.
+    """
+
+    config: list[CredentialsUserSwitchSaveConfigItem]

--- a/lib/nd_python/validators/switches/inventory_get.py
+++ b/lib/nd_python/validators/switches/inventory_get.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+
+
+class InventoryGetConfigItem(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for retrieving switches inventory.
+    """
+
+    fabric_name: str = Field(min_length=1, description="Fabric Name")
+
+
+class InventoryGetConfigValidator(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for retrieving switches inventory.
+    """
+
+    config: list[InventoryGetConfigItem]


### PR DESCRIPTION
CredentialsUserSwitchSave initial commit

This PR introduces a high-level class, endpoint definition and example script to save user credentials to switches in a fabric.

The implementation follows the established three-layer architecture pattern with a high-level class, endpoint definition, and example usage.

- Leverages the switch inventory retrieval introduced in the last commit
- Provides a complete example script with YAML configuration for practical usage

This commit also adds a validator:

lib/nd_python/validators/switches/inventory_get.py

that is used by the following example script:

examples/switches_inventory_get.py

This validator was accidently omitted in the last commit.