### PR TITLE
CredentialsUserSwitchDelete

### DIFF
--- a/examples/config/credentials_user_switch_delete.yaml
+++ b/examples/config/credentials_user_switch_delete.yaml
@@ -1,0 +1,14 @@
+---
+config:
+  - fabric_name: SITE1
+    switch_name: BG1
+  - fabric_name: SITE1
+    switch_name: LE1
+  - fabric_name: SITE1
+    switch_name: SP1
+  - fabric_name: SITE2
+    switch_name: BG2
+  - fabric_name: SITE2
+    switch_name: LE2
+  - fabric_name: SITE2
+    switch_name: SP2

--- a/examples/credentials_user_switch_delete.py
+++ b/examples/credentials_user_switch_delete.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-# credentials_user_switch_save.py
+# credentials_user_switch_delete.py
 
 ## Description
 
-Save user switch credentials to the controller.
+Delete user switch credentials from the controller.
 
 ## Usage
 
@@ -25,8 +25,8 @@ export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
 4. Run the script (below we're using command line for credentials)
 
 ``` bash
-./examples/credentials_user_switch_save.py \
-    --config ./examples/config/credentials_user_switch_save.yaml \
+./examples/credentials_user_switch_delete.py \
+    --config ./examples/config/credentials_user_switch_delete.yaml \
     --nd-domain local \
     --nd-ip4 10.1.1.1 \
     --nd-password password \
@@ -38,10 +38,9 @@ export ND_LOGGING_CONFIG=$HOME/repos/nd-python/lib/nd_python/logging_config.json
 The configuration file contains the following parameters:
 
 - config: Required; list of dictionaries with the following keys:
-    - fabric_name: Required; name of the fabric.
-    - switch_name: Required; name of the switch.
-    - switch_username: Required; username for the switch.
-    - switch_password: Required; password for the switch.
+  - switch_name: Required; name of the switch.
+  - switch_username: Required; username for the switch.
+  - switch_password: Required; password for the switch.
 """
 # pylint: disable=duplicate-code
 # We are using isort for import sorting.
@@ -56,7 +55,7 @@ from nd_python.common.nd_python_sender import NdPythonSender
 from nd_python.common.read_config import ReadConfig
 from nd_python.common.response_handler import ResponseHandler
 from nd_python.common.rest_send_v2 import RestSend
-from nd_python.credentials.user_switch_save import CredentialsUserSwitchSave
+from nd_python.credentials.user_switch_delete import CredentialsUserSwitchDelete
 from nd_python.parsers.parser_ansible_vault import parser_ansible_vault
 from nd_python.parsers.parser_config import parser_config
 from nd_python.parsers.parser_loglevel import parser_loglevel
@@ -64,23 +63,20 @@ from nd_python.parsers.parser_nd_domain import parser_nd_domain
 from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
 from nd_python.parsers.parser_nd_password import parser_nd_password
 from nd_python.parsers.parser_nd_username import parser_nd_username
-from nd_python.validators.credentials.user_switch_save import CredentialsUserSwitchSaveConfigItem, CredentialsUserSwitchSaveConfigValidator
+from nd_python.validators.credentials.user_switch_delete import CredentialsUserSwitchDeleteConfigValidator
 from pydantic import ValidationError
 
 
-def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
+def action(cfg: CredentialsUserSwitchDeleteConfigValidator) -> None:
     """
     Save user switch credentials.
     """
     # Prepopulate error message in case of failure
     errmsg = "Error saving user switch credentials. "
     try:
-        instance = CredentialsUserSwitchSave()
+        instance = CredentialsUserSwitchDelete()
         instance.rest_send = rest_send
-        instance.fabric_name = cfg.fabric_name
-        instance.switch_name = cfg.switch_name
-        instance.switch_username = cfg.switch_username
-        instance.switch_password = cfg.switch_password
+        instance.config = cfg
         instance.commit()
     except ValueError as error:
         errmsg += f"Error detail: {error}"
@@ -88,7 +84,8 @@ def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
         print(errmsg)
         return
 
-    print(f"fabric_name {cfg.fabric_name} switch_name {cfg.switch_name} switch_username {cfg.switch_username} credentials saved")
+    print("User switch credentials deleted successfully for the following devices:")
+    print(instance.result)
 
 
 def setup_parser() -> argparse.Namespace:
@@ -131,7 +128,7 @@ except ValueError as error:
     sys.exit(1)
 
 try:
-    validator = CredentialsUserSwitchSaveConfigValidator(**user_config.contents)
+    validator = CredentialsUserSwitchDeleteConfigValidator(**user_config.contents)
 except ValidationError as error:
     msg = f"{error}"
     log.error(msg)
@@ -154,5 +151,4 @@ rest_send.response_handler = ResponseHandler()
 rest_send.timeout = 2
 rest_send.send_interval = 5
 
-for item in validator.config:
-    action(item)
+action(validator.config)

--- a/lib/nd_python/credentials/user_switch_delete.py
+++ b/lib/nd_python/credentials/user_switch_delete.py
@@ -1,0 +1,183 @@
+"""
+# Name
+
+user_switch_delete.py
+
+# Description
+
+Delete user switch credentials from the controller.
+
+# Payload Example
+
+```json
+{
+  "switchIds": [
+    "SAL1948TRTT",
+    "SAL1947TRAB"
+  ]
+}
+```
+"""
+
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import inspect
+import logging
+
+from nd_python.common.properties import Properties
+from nd_python.endpoints.manage import EpCredentialsUserSwitchDelete
+from nd_python.switches.inventory_get import SwitchesInventoryGet
+from nd_python.validators.credentials.user_switch_delete import CredentialsUserSwitchDeleteConfigValidator
+
+
+class CredentialsUserSwitchDelete:
+    """
+    # Summary
+
+    Delete user switch credentials from the controller.
+
+    ## Example user switch delete request
+
+    ### See
+
+    ./examples/credentials_user_switch_delete.py
+    """
+
+    def __init__(self) -> None:
+        self.class_name = self.__class__.__name__
+        self.endpoint = EpCredentialsUserSwitchDelete()
+        self.inventory = SwitchesInventoryGet()
+        self.log = logging.getLogger(f"nd_python.{self.class_name}")
+        self.properties = Properties()
+        self.rest_send = self.properties.rest_send
+        self._result: str = ""
+
+        self._committed = False
+        self._config: dict[str, list[dict]] = {}
+        self._fabric_name = ""
+        self._fabric_inventory: dict[str, dict] = {}
+        self._payload: dict[str, list[str]] = {}
+        self._switch_name = ""
+
+    def _verify_property(self, method_name: str, property_name: str) -> None:
+        if not getattr(self, property_name, None):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.{property_name} must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+    def _final_verification(self) -> None:
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        self._verify_property(method_name, "config")
+        self._verify_property(method_name, "rest_send")
+
+    def populate_fabric_inventory(self, fabric_name: str) -> None:
+        """
+        Add fabric_name, if it exists, to self._fabric_inventory
+        """
+        method_name = inspect.stack()[0][3]
+        if fabric_name in self._fabric_inventory:
+            return
+        self.inventory.fabric_name = fabric_name
+        self.inventory.rest_send = self.rest_send
+        try:
+            self.inventory.commit()
+        except ValueError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Error populating fabric inventory for fabric {fabric_name}. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._fabric_inventory[fabric_name] = self.inventory.inventory_by_switch_name
+
+    def build_payload(self) -> None:
+        """
+        Build the payload for the request
+        """
+        self._payload = {}
+        _serial_numbers = []
+        for item in self.config:
+            self.populate_fabric_inventory(item.fabric_name)
+            serial_number = self._fabric_inventory.get(item.fabric_name, {}).get(item.switch_name, {}).get("serialNumber", "")
+            if not serial_number:
+                msg = f"switch_name {item.switch_name} not found in fabric {item.fabric_name}"
+                raise ValueError(msg)
+            self.result = f"Fabric {item.fabric_name} switch {item.switch_name} serial number {serial_number}.\n"
+            _serial_numbers.append(serial_number)
+        if len(_serial_numbers) == 0:
+            msg = "No valid switches found to delete credentials"
+            raise ValueError(msg)
+        self._payload = {
+            "switchIds": _serial_numbers,
+        }
+
+    def commit(self) -> None:
+        """
+        Save user switch credentials to the controller
+        """
+        method_name = inspect.stack()[0][3]
+        self._final_verification()
+        self.build_payload()
+
+        try:
+            self.rest_send.path = self.endpoint.path
+            self.rest_send.verb = self.endpoint.verb
+            self.rest_send.payload = self._payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Error sending {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._committed = True
+
+    @property
+    def config(self) -> CredentialsUserSwitchDeleteConfigValidator:
+        """
+        Set (setter) or return (getter) the configuration as a dictionary
+        """
+        return self._config
+
+    @config.setter
+    def config(self, value: CredentialsUserSwitchDeleteConfigValidator) -> None:
+        self._config = value
+
+    @property
+    def fabric_inventory(self) -> dict[str, dict]:
+        """
+        Return fabric_inventory (dict[str, dict])
+
+        Keyed on fabric_name, value is a dict keyed on switch_name with
+        values of dicts containing switch details.
+        """
+        method_name = inspect.stack()[0][3]
+        if not self._committed:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.commit must be called before accessing "
+            msg += f"{self.class_name}.{method_name}"
+            raise ValueError(msg)
+        return self._fabric_inventory
+
+    @property
+    def result(self) -> str:
+        """
+        Result of the commit operation.
+
+        Set (setter) or return (getter) the result as a string
+
+        The setter appends to the result string.
+        """
+        method_name = inspect.stack()[0][3]
+        if not self._committed:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.commit must be called before accessing "
+            msg += f"{self.class_name}.{method_name}"
+            raise ValueError(msg)
+        return self._result
+
+    @result.setter
+    def result(self, value: str) -> None:
+        self._result += value

--- a/lib/nd_python/endpoints/manage.py
+++ b/lib/nd_python/endpoints/manage.py
@@ -183,3 +183,12 @@ class EpCredentialsUserSwitchSave:
         self.verb = "POST"
         self.path = f"{credentials}/switches"
         self.description = "Save User Switch Credentials"
+
+
+class EpCredentialsUserSwitchDelete:
+    """Endpoint to delete user switch credentials"""
+
+    def __init__(self) -> None:
+        self.verb = "POST"
+        self.path = f"{credentials}/switches/actions/remove"
+        self.description = "Delete User Switch Credentials"

--- a/lib/nd_python/validators/credentials/user_switch_delete.py
+++ b/lib/nd_python/validators/credentials/user_switch_delete.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class CredentialsUserSwitchDeleteConfigItem(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for deleting user switch credentials.
+    """
+
+    fabric_name: str = Field(..., min_length=1, max_length=64, description="Fabric Name")
+    switch_name: str = Field(..., min_length=1, description="Switch Name")
+
+
+class CredentialsUserSwitchDeleteConfigValidator(BaseModel):
+    """
+    # Summary
+
+    Validate config parameters for deleting user switch credentials.
+    """
+
+    config: list[CredentialsUserSwitchDeleteConfigItem]


### PR DESCRIPTION
## Pull Request Overview

This commit introduces functionality to delete user switch credentials from the Nexus Dashboard controller, following the established three-layer architecture pattern. The implementation includes a high-level class for business logic, endpoint definition, and an example script with YAML configuration.

The high-level class differs from previous classes by accepting the Pydantic model directly.  This enables fewer requests to the controller and removes a deserialization/serialization step.  We plan to modify existing classes to follow this pattern in later PRs.

- Adds `CredentialsUserSwitchDelete` class for removing user switch credentials from specific switches in a fabric
- Provides complete example usage with YAML configuration template