### PR TITLE
Credentials user switch save

### DIFF
--- a/examples/credentials_user_switch_save.py
+++ b/examples/credentials_user_switch_save.py
@@ -64,11 +64,11 @@ from nd_python.parsers.parser_nd_domain import parser_nd_domain
 from nd_python.parsers.parser_nd_ip4 import parser_nd_ip4
 from nd_python.parsers.parser_nd_password import parser_nd_password
 from nd_python.parsers.parser_nd_username import parser_nd_username
-from nd_python.validators.credentials.user_switch_save import CredentialsUserSwitchSaveConfigItem, CredentialsUserSwitchSaveConfigValidator
+from nd_python.validators.credentials.user_switch_save import CredentialsUserSwitchSaveConfigValidator
 from pydantic import ValidationError
 
 
-def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
+def action(cfg: CredentialsUserSwitchSaveConfigValidator) -> None:
     """
     Save user switch credentials.
     """
@@ -76,11 +76,8 @@ def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
     errmsg = "Error saving user switch credentials. "
     try:
         instance = CredentialsUserSwitchSave()
+        instance.config = cfg
         instance.rest_send = rest_send
-        instance.fabric_name = cfg.fabric_name
-        instance.switch_name = cfg.switch_name
-        instance.switch_username = cfg.switch_username
-        instance.switch_password = cfg.switch_password
         instance.commit()
     except ValueError as error:
         errmsg += f"Error detail: {error}"
@@ -88,7 +85,7 @@ def action(cfg: CredentialsUserSwitchSaveConfigItem) -> None:
         print(errmsg)
         return
 
-    print(f"fabric_name {cfg.fabric_name} switch_name {cfg.switch_name} switch_username {cfg.switch_username} credentials saved")
+    print(instance.result)
 
 
 def setup_parser() -> argparse.Namespace:
@@ -154,5 +151,4 @@ rest_send.response_handler = ResponseHandler()
 rest_send.timeout = 2
 rest_send.send_interval = 5
 
-for item in validator.config:
-    action(item)
+action(validator)

--- a/lib/nd_python/credentials/user_switch_delete.py
+++ b/lib/nd_python/credentials/user_switch_delete.py
@@ -51,13 +51,13 @@ class CredentialsUserSwitchDelete:
         self.log = logging.getLogger(f"nd_python.{self.class_name}")
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
-        self._result: str = ""
 
         self._committed = False
         self._config: dict[str, list[dict]] = {}
         self._fabric_name = ""
         self._fabric_inventory: dict[str, dict] = {}
         self._payload: dict[str, list[str]] = {}
+        self._result: str = ""
         self._switch_name = ""
 
     def _verify_property(self, method_name: str, property_name: str) -> None:
@@ -137,7 +137,7 @@ class CredentialsUserSwitchDelete:
     @property
     def config(self) -> CredentialsUserSwitchDeleteConfigValidator:
         """
-        Set (setter) or return (getter) the configuration as a dictionary
+        Set (setter) or return (getter) the configuration as a Pydantic model
         """
         return self._config
 

--- a/lib/nd_python/credentials/user_switch_save.py
+++ b/lib/nd_python/credentials/user_switch_save.py
@@ -60,7 +60,7 @@ class CredentialsUserSwitchSave:
         self.rest_send = self.properties.rest_send
 
         self._committed = False
-        self._config: dict[str, list[dict]] = {}
+        self._config: CredentialsUserSwitchSaveConfigValidator
         self._fabric_name = ""
         self._fabric_inventory: dict[str, dict] = {}
         self._payload: dict[str, Any] = {}
@@ -108,22 +108,22 @@ class CredentialsUserSwitchSave:
         """
         self._result = "User switch credentials saved successfully for the following devices:\n"
         _serial_numbers = []
-        for item in self.config.switches:
+        for item in self._config.switches:
             self.populate_fabric_inventory(item.fabric_name)
             serial_number = self._fabric_inventory.get(item.fabric_name, {}).get(item.switch_name, {}).get("serialNumber", "")
             if not serial_number:
                 msg = f"switch_name {item.switch_name} not found in fabric {item.fabric_name}"
                 raise ValueError(msg)
             _serial_numbers.append({"switchId": serial_number})
-            self.result = f"Fabric {item.fabric_name} switch {item.switch_name} serial number {serial_number} switch_username {self.config.switch_username}.\n"
+            self.result = f"Fabric {item.fabric_name} switch {item.switch_name} serial number {serial_number} switch_username {self._config.switch_username}.\n"
 
         if len(_serial_numbers) == 0:
             msg = "No valid switches found to save credentials"
             raise ValueError(msg)
 
         self._payload["switchIds"] = _serial_numbers
-        self._payload["switchUsername"] = self.config.switch_username
-        self._payload["switchPassword"] = self.config.switch_password
+        self._payload["switchUsername"] = self._config.switch_username
+        self._payload["switchPassword"] = self._config.switch_password
 
     def commit(self) -> None:
         """

--- a/lib/nd_python/validators/credentials/user_switch_save.py
+++ b/lib/nd_python/validators/credentials/user_switch_save.py
@@ -1,17 +1,15 @@
 from pydantic import BaseModel, Field
 
 
-class CredentialsUserSwitchSaveConfigItem(BaseModel):
+class Switches(BaseModel):
     """
     # Summary
 
-    Validate config parameters for saving user switch credentials.
+    Information needed to target specific switches.
     """
 
     fabric_name: str = Field(..., min_length=1, max_length=64, description="Fabric Name")
     switch_name: str = Field(..., min_length=1, description="Switch Name")
-    switch_username: str = Field(..., min_length=1, description="Switch Username")
-    switch_password: str = Field(..., min_length=1, description="Switch Password")
 
 
 class CredentialsUserSwitchSaveConfigValidator(BaseModel):
@@ -21,4 +19,6 @@ class CredentialsUserSwitchSaveConfigValidator(BaseModel):
     Validate config parameters for saving user switch credentials.
     """
 
-    config: list[CredentialsUserSwitchSaveConfigItem]
+    switch_username: str = Field(..., min_length=1, description="Switch Username")
+    switch_password: str = Field(..., min_length=1, description="Switch Password")
+    switches: list[Switches]


### PR DESCRIPTION
CredentialsUserSwitchSave: pass validator directly

This PR includes the following:

1. Modifies the CredentialsUserSwitchSave class to accept a Pydantic model of the user’s configuration directly, saving a deserialization step in user  scripts that leverage this class.

2. Modify the Pydantic model to more closely resemble the payload, while retaining user-friendly fabric_name+switch_name to target switches (versus using serial_number required by the payload).  This modification was also needed because the controller rejects payloads with different usernames/passwords for different switches.  Finally, the modification simplifies the configuration since we no longer have to include username/password with every switch.

3. We also made a couple very minor changes to the CredentialsUserSwitchDelete class (fix the config docstring, and move self._result in __init__ into its proper order alphabetically for better readability).