### PR TITLE
CredentialsDefaultSwitchSave: refactor

### DIFF
--- a/examples/credentials_default_switch_save.py
+++ b/examples/credentials_default_switch_save.py
@@ -68,8 +68,7 @@ def action(cfg: CredentialsDefaultSwitchSaveConfigValidator) -> None:
     try:
         instance = CredentialsDefaultSwitchSave()
         instance.rest_send = rest_send
-        instance.switch_username = cfg.switch_username
-        instance.switch_password = cfg.switch_password
+        instance.config = cfg
         instance.commit()
     except ValueError as error:
         errmsg += f"Error detail: {error}"

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -55,11 +55,11 @@ class CredentialsDefaultSwitchSave:
         """Verify that a property is set before calling commit.
 
         Args:
-            method_name (str): _description_
-            property_name (str): _description_
+            method_name (str): The calling method name
+            property_name (str): The name of the property to validate
 
         Raises:
-            ValueError: _description_
+            ValueError: If the property is not set
         """
         if getattr(self, property_name, None) is None:
             msg = f"{self.class_name}.{method_name}: "

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -48,7 +48,7 @@ class CredentialsDefaultSwitchSave:
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
 
-        self._config: CredentialsDefaultSwitchSaveConfigValidator
+        self._config = None
         self._payload: dict[str, str] = {}
 
     def _verify_property(self, method_name: str, property_name: str) -> None:

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -25,6 +25,7 @@ import logging
 
 from nd_python.common.properties import Properties
 from nd_python.endpoints.manage import EpCredentialsDefaultSwitchSave
+from nd_python.validators.credentials.default_switch_save import CredentialsDefaultSwitchSaveConfigValidator
 
 
 class CredentialsDefaultSwitchSave:
@@ -47,32 +48,23 @@ class CredentialsDefaultSwitchSave:
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
 
+        self._config: CredentialsDefaultSwitchSaveConfigValidator
         self._payload: dict[str, str] = {}
-        self._switch_username = ""
-        self._switch_password = ""
+
+    def _verify_property(self, method_name: str, property_name: str) -> None:
+        if not getattr(self, property_name, None):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.{property_name} must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
 
     def _final_verification(self) -> None:
         """
         final verification of all parameters
         """
         method_name = inspect.stack()[0][3]
-
-        if self.rest_send is None:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"{self.class_name}.rest_send must be set before calling "
-            msg += f"{self.class_name}.commit"
-            raise ValueError(msg)
-
-        if self._switch_username == "":
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Call {self.class_name}.switch_username "
-            msg += f"before calling {self.class_name}.commit"
-            raise ValueError(msg)
-        if self._switch_password == "":
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Call {self.class_name}.switch_password "
-            msg += f"before calling {self.class_name}.commit"
-            raise ValueError(msg)
+        self._verify_property(method_name, "config")
+        self._verify_property(method_name, "rest_send")
 
     def commit(self) -> None:
         """
@@ -81,8 +73,8 @@ class CredentialsDefaultSwitchSave:
         method_name = inspect.stack()[0][3]
         self._final_verification()
 
-        self.endpoint.switch_username = self._switch_username
-        self.endpoint.switch_password = self._switch_password
+        self.endpoint.switch_username = self._config.switch_username
+        self.endpoint.switch_password = self._config.switch_password
         try:
             self.endpoint.commit()
         except ValueError as error:
@@ -91,8 +83,8 @@ class CredentialsDefaultSwitchSave:
             msg += f"Error details: {error}"
             raise ValueError(msg) from error
 
-        self._payload["switchUsername"] = self.endpoint.switch_username
-        self._payload["switchPassword"] = self.endpoint.switch_password
+        self._payload["switchUsername"] = self._config.switch_username
+        self._payload["switchPassword"] = self._config.switch_password
         try:
             self.rest_send.path = self.endpoint.path
             self.rest_send.verb = self.endpoint.verb
@@ -105,23 +97,12 @@ class CredentialsDefaultSwitchSave:
             raise ValueError(msg) from error
 
     @property
-    def switch_password(self) -> str:
+    def config(self) -> CredentialsDefaultSwitchSaveConfigValidator:
         """
-        Set (setter) or return (getter) the current value of switch_password
+        Set (setter) or return (getter) the current value of config
         """
-        return self._switch_password
+        return self._config
 
-    @switch_password.setter
-    def switch_password(self, value: str) -> None:
-        self._switch_password = value
-
-    @property
-    def switch_username(self) -> str:
-        """
-        Set (setter) or return (getter) the current value of switch_username
-        """
-        return self._switch_username
-
-    @switch_username.setter
-    def switch_username(self, value: str) -> None:
-        self._switch_username = value
+    @config.setter
+    def config(self, value: CredentialsDefaultSwitchSaveConfigValidator) -> None:
+        self._config = value

--- a/lib/nd_python/credentials/default_switch_save.py
+++ b/lib/nd_python/credentials/default_switch_save.py
@@ -48,11 +48,20 @@ class CredentialsDefaultSwitchSave:
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
 
-        self._config = None
+        self._config: CredentialsDefaultSwitchSaveConfigValidator = None
         self._payload: dict[str, str] = {}
 
     def _verify_property(self, method_name: str, property_name: str) -> None:
-        if not getattr(self, property_name, None):
+        """Verify that a property is set before calling commit.
+
+        Args:
+            method_name (str): _description_
+            property_name (str): _description_
+
+        Raises:
+            ValueError: _description_
+        """
+        if getattr(self, property_name, None) is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.{property_name} must be set before calling "
             msg += f"{self.class_name}.commit"


### PR DESCRIPTION
## Pull Request Overview

This pull request refactors the CredentialsDefaultSwitchSave class to accept a Pydantic model directly instead of individual properties, streamlining the design and eliminating redundant deserialization steps.

Key changes:
- Modified CredentialsUserSwitchSave to accept the validator model directly via a config property