### PR TITLE
CredentialsRobotSwitchSave refactor

### DIFF
--- a/examples/credentials_robot_switch_save.py
+++ b/examples/credentials_robot_switch_save.py
@@ -68,8 +68,7 @@ def action(cfg: CredentialsRobotSwitchSaveConfigValidator) -> None:
     try:
         instance = CredentialsRobotSwitchSave()
         instance.rest_send = rest_send
-        instance.switch_username = cfg.switch_username
-        instance.switch_password = cfg.switch_password
+        instance.config = cfg
         instance.commit()
     except ValueError as error:
         errmsg += f"Error detail: {error}"
@@ -77,9 +76,8 @@ def action(cfg: CredentialsRobotSwitchSaveConfigValidator) -> None:
         print(errmsg)
         return
 
-    result_msg = f"robot switch credentials saved for user {cfg.switch_username}"
-    log.info(result_msg)
-    print(result_msg)
+    log.info(instance.result)
+    print(instance.result)
 
 
 def setup_parser() -> argparse.Namespace:

--- a/lib/nd_python/credentials/robot_switch_save.py
+++ b/lib/nd_python/credentials/robot_switch_save.py
@@ -63,13 +63,7 @@ class CredentialsRobotSwitchSave:
         Raises:
             ValueError: If the property is not set
         """
-        # Map property names to the actual attribute to check
-        attr_map = {
-            "config": "_config",
-            "rest_send": "rest_send",
-        }
-        attr_name = attr_map.get(property_name, property_name)
-        if getattr(self, attr_name, None) is None:
+        if getattr(self, property_name, None) is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.{property_name} must be set before calling "
             msg += f"{self.class_name}.commit"
@@ -80,10 +74,8 @@ class CredentialsRobotSwitchSave:
         final verification of all parameters
         """
         method_name = inspect.stack()[0][3]
-        self._verify_property(method_name, "config")
-        if self.properties.rest_send is None:
-            msg = f"{self.class_name}.{method_name}: self.properties.rest_send must be set before calling {self.class_name}.commit"
-            raise ValueError(msg)
+        self._verify_property(method_name, "_config")
+        self._verify_property(method_name, "rest_send")
 
     def commit(self) -> None:
         """

--- a/lib/nd_python/credentials/robot_switch_save.py
+++ b/lib/nd_python/credentials/robot_switch_save.py
@@ -63,7 +63,13 @@ class CredentialsRobotSwitchSave:
         Raises:
             ValueError: If the property is not set
         """
-        if getattr(self, property_name, None) is None:
+        # Map property names to the actual attribute to check
+        attr_map = {
+            "config": "_config",
+            "rest_send": "rest_send",
+        }
+        attr_name = attr_map.get(property_name, property_name)
+        if getattr(self, attr_name, None) is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.{property_name} must be set before calling "
             msg += f"{self.class_name}.commit"

--- a/lib/nd_python/credentials/robot_switch_save.py
+++ b/lib/nd_python/credentials/robot_switch_save.py
@@ -81,7 +81,9 @@ class CredentialsRobotSwitchSave:
         """
         method_name = inspect.stack()[0][3]
         self._verify_property(method_name, "config")
-        self._verify_property(method_name, "rest_send")
+        if self.properties.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: self.properties.rest_send must be set before calling {self.class_name}.commit"
+            raise ValueError(msg)
 
     def commit(self) -> None:
         """


### PR DESCRIPTION
## Pull Request Overview

This refactor simplifies the CredentialsRobotSwitchSave class by replacing individual property setters with a single Pydantic configuration object, eliminating redundant parameter handling and improving type safety.

- Replaced individual switch_username and switch_password properties with a single config property
- Streamlined parameter verification using a generic helper method
- Updated the example script to use the new configuration approach